### PR TITLE
Added tslint to compile task in gulpfile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -4,6 +4,7 @@
     typescript = require('gulp-typescript'),
     sourcemaps = require('gulp-sourcemaps'),
     watch      = require('gulp-watch'),
+    tslint     = require('gulp-tslint'),
     del        = require('del'),
     runSeq     = require('run-sequence'),
 
@@ -73,6 +74,12 @@ gulp.task('inject', function () {
 gulp.task('compile', function () {
     var tsProject = typescript.createProject(paths.src + '/tsconfig.json');
     return gulp.src(tsFiles)
+        .pipe(tslint({
+            formatter: 'prose'
+        }))
+        .pipe(tslint.report({
+            emitError: false
+        }))
         .pipe(sourcemaps.init())
         .pipe(typescript(tsProject))
         .pipe(sourcemaps.write('.'))

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp": "^3.9.1",
     "gulp-inject": "^4.1.0",
     "gulp-sourcemaps": "^1.6.0",
+    "gulp-tslint": "^6.1.1",
     "gulp-typescript": "^2.13.6",
     "gulp-watch": "^4.3.9",
     "lite-server": "^2.2.2",


### PR DESCRIPTION
I have updated the gulpfile and performed some tests, and discovered the following: 
- Warnings will be reported, but will not stop the Typescript from being transpiled.
- Errors will also be reported, and will prevent the Typescript from being transpiled.

If you could also do some testing, that would be great!
